### PR TITLE
Fixes #24

### DIFF
--- a/PSP-Inventory/private/_GetSysInfo.ps1
+++ b/PSP-Inventory/private/_GetSysInfo.ps1
@@ -13,7 +13,7 @@ function _GetSysInfo {
         Manufacturer              = $CS.Manufacturer
         Model                     = $CS.Model
         SystemType                = $CS.SystemType
-        State                     = if ($CS.Manufacturer -match "Hyper|Citrix|VMWare|virtual") {'Virtual'}else {'Physical'}
+        State                     = if ($CS.Manufacturer -match "Hyper|Citrix|VMWare|virtual|Microsoft") {'Virtual'}else {'Physical'}
         SerialNumber              = $Enclosure.SerialNumber
         ChassisType               = (Convert-ChassisType $Enclosure.ChassisTypes)
         Description               = $Enclosure.Description


### PR DESCRIPTION
Fixes #24 - `Get-PspSysInfo` correctly displays Hyper-V VM's as Virtual instead of Physical machines