### PR TITLE
Closes #25 & #26, Fixes #24 - ready for v1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.0.1] - 2019-03-14
+
+### Added
+
+- [Issue #24](https://github.com/powershellpr0mpt/PSP-Inventory/issues/25) - Added a check to see if Get-PspServerRole is run on a workstation or not.
+- [Issue #25](https://github.com/powershellpr0mpt/PSP-Inventory/issues/26) - Added a check to see if Get-PspLocalUser is run on a Domain Controller or not.
+
+### Fixed
+
+- [Issue #24](https://github.com/powershellpr0mpt/PSP-Inventory/issues/24) - Correctly displays Hyper-V VMs as virtual machines now
+
+---
+
 ## [1.0.0] - 2019-03-12
 
 ### BREAKING
@@ -15,61 +28,68 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- [Issue #2](https://github.com/powershellpr0mpt/PSP-Inventory/issues/2) - Added external help
-- [Issue #10](https://github.com/powershellpr0mpt/PSP-Inventory/issues/10) - Added native PsProvider access to registry
-- [Issue #13](https://github.com/powershellpr0mpt/PSP-Inventory/issues/13) - Added CIM/PSSession functionality for improved performance
+- [Issue #2](https://github.com/powershellpr0mpt/PSP-Inventory/issues/2) - Added external help.
+- [Issue #10](https://github.com/powershellpr0mpt/PSP-Inventory/issues/10) - Added native PsProvider access to registry.
+- [Issue #13](https://github.com/powershellpr0mpt/PSP-Inventory/issues/13) - Added CIM/PSSession functionality for improved performance.
 
 ### Fixed
 
-- [Issue #7](https://github.com/powershellpr0mpt/PSP-Inventory/issues/7) - Due to new help system, new Pester test has been made to check availability of help
+- [Issue #7](https://github.com/powershellpr0mpt/PSP-Inventory/issues/7) - Due to new help system, new Pester test has been made to check availability of help.
+
+---
 
 ## [0.9.2] - 2019-03-05
 
 ### Changed
 
-- [Issue #8](https://github.com/powershellpr0mpt/PSP-Inventory/issues/8) - No longer exports private functions
-- [Issue #9](https://github.com/powershellpr0mpt/PSP-Inventory/issues/9) - InventoryDate property is now a proper [datetime] object
-
+- [Issue #8](https://github.com/powershellpr0mpt/PSP-Inventory/issues/8) - No longer exports private functions.
+- [Issue #9](https://github.com/powershellpr0mpt/PSP-Inventory/issues/9) - InventoryDate property is now a proper [datetime] object.
 
 ### Fixed
 
-- [Issue #17](https://github.com/powershellpr0mpt/PSP-Inventory/issues/17) - Various cmdlets now include custom display formats
-- [Issue #18](https://github.com/powershellpr0mpt/PSP-Inventory/issues/18) - The WinZIP build task now creates an archive as expected when all tests are successful. Getting the tests to run successful is still an issue though, see [Issue #7](https://github.com/powershellpr0mpt/PSP-Inventory/issues/7)
+- [Issue #17](https://github.com/powershellpr0mpt/PSP-Inventory/issues/17) - Various cmdlets now include custom display formats.
+- [Issue #18](https://github.com/powershellpr0mpt/PSP-Inventory/issues/18) - The WinZIP build task now creates an archive as expected. when all tests are successful. Getting the tests to run successful is still an issue though, see [Issue #7](https://github.com/powershellpr0mpt/PSP-Inventory/issues/7).
+
+---
 
 ## [0.9.1] - 2019-03-01
 
 ### Changed
 
-- [Issue #3](https://github.com/powershellpr0mpt/PSP-Inventory/pull/3) - ComputerName property always displays in uppercase
-- Get-RemoteCertificate includes more properties [Subject/HasPrivateKey]
-- Changed Notes and Link URLs to https
+- [Issue #3](https://github.com/powershellpr0mpt/PSP-Inventory/pull/3) - ComputerName property always displays in uppercase.
+- Get-RemoteCertificate includes more properties [Subject/HasPrivateKey].
+- Changed Notes and Link URLs to https.
 
 ### Fixed
 
-- [Issue #5](https://github.com/powershellpr0mpt/PSP-Inventory/pull/5) - Inventory date on Get-SecurityUpdate and Get-Software incorrect
+- [Issue #5](https://github.com/powershellpr0mpt/PSP-Inventory/pull/5) - Inventory date on Get-SecurityUpdate and Get-Software incorrect.
+
+---
 
 ## [0.9.0] - 2019-02-28
 
 ### Added
 
-- Working Pester tests
+- Working Pester tests.
 
 ### Changed
 
-- Updated build scripts
-- Updated Changelog and Contribution documentation
+- Updated build scripts.
+- Updated Changelog and Contribution documentation.
 
 ### Removed
 
-- Old scripts that were no longer used/required
+- Old scripts that were no longer used/required.
 
 ### Known Issues
 
-- Pester test for help files on Get-RemoteCertificate script provides an error on the StoreLocation and StoreName type
+- Pester test for help files on Get-RemoteCertificate script provides an error on the StoreLocation and StoreName type.
+
+---
 
 ## [Unreleased]
 
 ### Changed
 
-- Cleaning up folder structure and moving all parts to the correct location
-- Adding comment based help for all public functions
+- Cleaning up folder structure and moving all parts to the correct location.
+- Adding comment based help for all public functions.

--- a/PSP-Inventory/PSP-Inventory.psd1
+++ b/PSP-Inventory/PSP-Inventory.psd1
@@ -12,7 +12,7 @@
     RootModule        = 'PSP-Inventory.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '1.0.0'
+    ModuleVersion     = '1.0.1'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/PSP-Inventory/PSP-Inventory.psm1
+++ b/PSP-Inventory/PSP-Inventory.psm1
@@ -6,7 +6,7 @@
 
         Name: PSP-Inventory
         Author: Robert Prust
-        Version: 1.0.0
+        Version: 1.0.1
         Blog: https://powershellpr0mpt.com
 
     .LINK

--- a/PSP-Inventory/private/_GetLocalUser.ps1
+++ b/PSP-Inventory/private/_GetLocalUser.ps1
@@ -46,18 +46,24 @@ function _GetLocalUser {
             $List -join '; '
         }
         $Computer = $env:COMPUTERNAME.ToUpper()
-        $UserInfo = ([ADSI]"WinNT://$Computer").Children | Where-Object {$_.SchemaClassName -eq 'User'}
-        foreach ($User in $UserInfo) {
-            [PSCustomObject]@{
-                PSTypeName    = 'PSP.Inventory.LocalUser'
-                ComputerName  = $Computer
-                UserName      = $User.Name[0]
-                Description   = $User.Description[0]
-                LastLogin     = if ($User.LastLogin[0] -is [datetime]) {$User.LastLogin[0]}else {$null}
-                SID           = (ConvertTo-SID -BinarySID $User.ObjectSid[0])
-                UserFlags     = (Convert-UserFlag -UserFlag $User.UserFlags[0])
-                InventoryDate = (Get-Date)
+        #Check if Domain Controller - https://docs.microsoft.com/en-us/windows/desktop/CIMWin32Prov/win32-operatingsystem#properties
+        $ProductType = (Get-CimInstance -ClassName Win32_OperatingSystem -Property ProductType).ProductType
+        if (!($ProductType -eq 2)){
+            $UserInfo = ([ADSI]"WinNT://$Computer").Children | Where-Object {$_.SchemaClassName -eq 'User'}
+            foreach ($User in $UserInfo) {
+                [PSCustomObject]@{
+                    PSTypeName    = 'PSP.Inventory.LocalUser'
+                    ComputerName  = $Computer
+                    UserName      = $User.Name[0]
+                    Description   = $User.Description[0]
+                    LastLogin     = if ($User.LastLogin[0] -is [datetime]) {$User.LastLogin[0]}else {$null}
+                    SID           = (ConvertTo-SID -BinarySID $User.ObjectSid[0])
+                    UserFlags     = (Convert-UserFlag -UserFlag $User.UserFlags[0])
+                    InventoryDate = (Get-Date)
+                }
             }
+        }else {
+            Write-Warning "[$Computer] - is a Domain Controller, no local users available"
         }
     }
 }

--- a/PSP-Inventory/private/_GetRoleInfo.ps1
+++ b/PSP-Inventory/private/_GetRoleInfo.ps1
@@ -4,13 +4,19 @@ function _GetRoleInfo {
         [Microsoft.Management.Infrastructure.CimSession]$Cimsession
     )
     Write-Verbose "[$($CimSession.ComputerName)] - Gathering Server Role information"
-    Get-CimInstance -CimSession $CimSession -ClassName Win32_ServerFeature -Property Id, Name -ErrorAction Stop | ForEach-Object {
-        [PSCustomObject]@{
-            PSTypeName    = 'PSP.Inventory.ServerRole'
-            ComputerName  = $Cimsession.ComputerName
-            RoleId        = $_.Id
-            Name          = $_.Name
-            InventoryDate = (Get-Date)
+    #Check if Workstation - https://docs.microsoft.com/en-us/windows/desktop/CIMWin32Prov/win32-operatingsystem#properties
+    $ProductType = (Get-CimInstance -CimSession $CimSession -ClassName Win32_OperatingSystem -Property ProductType).ProductType
+    if (!($ProductType -eq 1)){
+        Get-CimInstance -CimSession $CimSession -ClassName Win32_ServerFeature -Property Id, Name -ErrorAction Stop | ForEach-Object {
+            [PSCustomObject]@{
+                PSTypeName    = 'PSP.Inventory.ServerRole'
+                ComputerName  = $CimSession.ComputerName
+                RoleId        = $_.Id
+                Name          = $_.Name
+                InventoryDate = (Get-Date)
+            }
         }
+    }else{
+        Write-Warning "[$($CimSession.ComputerName)] - is a workstation, no roles available"
     }
 }

--- a/PSP-Inventory/private/_GetSysInfo.ps1
+++ b/PSP-Inventory/private/_GetSysInfo.ps1
@@ -13,7 +13,7 @@ function _GetSysInfo {
         Manufacturer              = $CS.Manufacturer
         Model                     = $CS.Model
         SystemType                = $CS.SystemType
-        State                     = if ($CS.Manufacturer -match "Hyper|Citrix|VMWare|virtual") {'Virtual'}else {'Physical'}
+        State                     = if ($CS.Manufacturer -match "Hyper|Citrix|VMWare|virtual|Microsoft") {'Virtual'}else {'Physical'}
         SerialNumber              = $Enclosure.SerialNumber
         ChassisType               = (Convert-ChassisType $Enclosure.ChassisTypes)
         Description               = $Enclosure.Description

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # PSP-Inventory
 
+![PowerShell Gallery](https://img.shields.io/powershellgallery/v/PSP-Inventory.svg?label=PSGallery%20Version&logo=PowerShell&style=flat-square)
+![PowerShell Gallery](https://img.shields.io/powershellgallery/dt/PSP-Inventory.svg?label=PSGallery%20Downloads&logo=PowerShell&style=flat-square)
+
 ## What does it do
 
 The PSP-Inventory module provides new cmdlets for you to inventorise your Windows environment.


### PR DESCRIPTION
Check if Get-PspLocalUser runs on a domain controller. Fixes #26
Check if Get-PspServerRole runs on a workstation. Closes #25
Correctly check for machine manufacturer. Fixes #24
Update CHANGELOG, README, psm1 and psd1  - ready for v1.0.1